### PR TITLE
AT Protocol Bridge: Phase 5.5 integration with mastopod-federation-ar…

### DIFF
--- a/api/src/db/atBridgeSchema.ts
+++ b/api/src/db/atBridgeSchema.ts
@@ -1,0 +1,205 @@
+/**
+ * AT Protocol Bridge — Database Schema
+ *
+ * Extends the memory app's existing schema with tables that store
+ * federated AT Protocol content received via the Phase 5.5 ingress pipeline.
+ *
+ * Design principles:
+ *   - AT content is stored separately from ActivityPods content to preserve
+ *     provenance and allow independent lifecycle management.
+ *   - The atPosts table mirrors the structure of the existing posts table
+ *     so the frontend can render both sources uniformly.
+ *   - The atIdentities table caches DID → handle mappings for display.
+ *   - All AT-sourced content is marked with its source DID and rkey for
+ *     deduplication and AT URI reconstruction.
+ *
+ * Security notes:
+ *   - Content is stored as received; sanitisation happens at render time.
+ *   - The sourceUrl field is validated before storage.
+ *   - No user credentials are stored in this schema.
+ */
+
+import { text, serial, pgTable as table, timestamp, boolean, integer, varchar, jsonb, pgView } from 'drizzle-orm/pg-core'
+import { sql } from 'drizzle-orm'
+import { users } from './schema'
+
+// ---------------------------------------------------------------------------
+// AT Identities (DID → handle cache)
+// ---------------------------------------------------------------------------
+
+/**
+ * Caches resolved AT Protocol identities for display in the UI.
+ * Updated whenever an #identity event is processed by the verifier.
+ */
+export const atIdentities = table('at_identities', {
+  id: serial().primaryKey(),
+
+  /** ATProto DID (e.g. did:plc:abc123). */
+  did: varchar('did', { length: 2048 }).notNull().unique(),
+
+  /** Current handle (e.g. alice.bsky.social). May be null if unresolved. */
+  handle: varchar('handle', { length: 512 }),
+
+  /** Full DID document as JSON. */
+  didDocument: jsonb('did_document'),
+
+  /** Whether this identity is currently active. */
+  isActive: boolean('is_active').notNull().default(true),
+
+  /** ISO-8601 timestamp of last successful resolution. */
+  resolvedAt: timestamp('resolved_at', { withTimezone: true }).defaultNow(),
+
+  /** ISO-8601 timestamp of last update from the ingress pipeline. */
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+
+  /**
+   * Optional link to a local memory user.
+   * Set when a local user has linked their AT identity.
+   */
+  localUserId: integer('local_user_id').references(() => users.id),
+})
+
+// ---------------------------------------------------------------------------
+// AT Posts (federated content from the AT firehose)
+// ---------------------------------------------------------------------------
+
+/**
+ * Stores AT Protocol posts received via the Phase 5.5 ingress pipeline.
+ * These are posts from external ATProto users that are relevant to local users
+ * (e.g. followed accounts, mentioned users).
+ */
+export const atPosts = table('at_posts', {
+  id: serial().primaryKey(),
+
+  /** ATProto DID of the author. */
+  authorDid: varchar('author_did', { length: 2048 }).notNull(),
+
+  /** ATProto record key (rkey) for deduplication. */
+  rkey: varchar('rkey', { length: 512 }).notNull(),
+
+  /** Full AT URI (at://did:plc:xxx/app.bsky.feed.post/rkey). */
+  atUri: varchar('at_uri', { length: 3072 }).notNull().unique(),
+
+  /** Content-addressed CID of the record. */
+  cid: varchar('cid', { length: 512 }),
+
+  /** Post text content. */
+  content: text('content').notNull(),
+
+  /** Whether this post is publicly visible. */
+  isPublic: boolean('is_public').notNull().default(true),
+
+  /** Facets (mentions, links, tags) as JSON. */
+  facets: jsonb('facets'),
+
+  /** Embed data (images, external links, quotes) as JSON. */
+  embeds: jsonb('embeds'),
+
+  /** AT URI of the parent post if this is a reply. */
+  replyParentUri: varchar('reply_parent_uri', { length: 3072 }),
+
+  /** AT URI of the root post in the reply thread. */
+  replyRootUri: varchar('reply_root_uri', { length: 3072 }),
+
+  /** ISO-8601 timestamp from the ATProto record. */
+  createdAt: timestamp('created_at', { withTimezone: true }),
+
+  /** ISO-8601 timestamp of local ingestion. */
+  ingestedAt: timestamp('ingested_at', { withTimezone: true }).defaultNow(),
+
+  /** Upstream firehose source (e.g. wss://relay.bsky.network). */
+  sourceRelay: varchar('source_relay', { length: 512 }),
+
+  /** ATProto firehose sequence number for ordering and deduplication. */
+  firehoseSeq: integer('firehose_seq'),
+})
+
+// ---------------------------------------------------------------------------
+// AT Firehose Cursor State (for UI observability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Exposes the current firehose cursor state for each source relay.
+ * Used by the admin UI to monitor ingestion health.
+ */
+export const atFirehoseCursors = table('at_firehose_cursors', {
+  id: serial().primaryKey(),
+
+  /** Source relay identifier (e.g. wss://relay.bsky.network). */
+  sourceId: varchar('source_id', { length: 512 }).notNull().unique(),
+
+  /** Source type: relay or PDS. */
+  sourceType: varchar('source_type', { length: 16 }).notNull().default('relay'),
+
+  /** Last committed cursor seq number. */
+  committedSeq: integer('committed_seq'),
+
+  /** Last hot cursor seq number. */
+  hotSeq: integer('hot_seq'),
+
+  /** Whether the source is currently connected. */
+  isConnected: boolean('is_connected').notNull().default(false),
+
+  /** ISO-8601 timestamp of last event received. */
+  lastEventAt: timestamp('last_event_at', { withTimezone: true }),
+
+  /** ISO-8601 timestamp of last cursor commit. */
+  lastCommitAt: timestamp('last_commit_at', { withTimezone: true }),
+
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+})
+
+// ---------------------------------------------------------------------------
+// Unified Feed View (AT + ActivityPods posts)
+// ---------------------------------------------------------------------------
+
+/**
+ * A unified view combining ActivityPods posts and AT Protocol posts for the
+ * memory UI's home feed.  Both sources are normalised to the same shape.
+ */
+export const unifiedFeedView = pgView('unified_feed_view', {
+  id: serial().primaryKey(),
+  content: text('content').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }),
+  isPublic: boolean('is_public').notNull(),
+  authorId: integer('author_id'),
+  authorName: text('author_name').notNull(),
+  authorWebId: text('author_web_id').notNull(),
+  authorProviderEndpoint: text('author_provider_endpoint').notNull(),
+  /** 'activitypods' | 'atproto' */
+  source: varchar('source', { length: 32 }).notNull(),
+  /** AT URI for ATProto posts, null for ActivityPods posts. */
+  atUri: varchar('at_uri', { length: 3072 }),
+}).as(sql`
+  SELECT
+    posts.id,
+    posts.content,
+    posts.created_at,
+    posts.is_public,
+    posts.author_id,
+    users.name as author_name,
+    users.web_id as author_web_id,
+    users.provider_endpoint as author_provider_endpoint,
+    'activitypods' as source,
+    NULL::varchar as at_uri
+  FROM posts
+  INNER JOIN users ON posts.author_id = users.id
+  WHERE posts.is_public = true
+
+  UNION ALL
+
+  SELECT
+    at_posts.id,
+    at_posts.content,
+    at_posts.created_at,
+    at_posts.is_public,
+    NULL::integer as author_id,
+    COALESCE(at_identities.handle, at_posts.author_did) as author_name,
+    at_posts.author_did as author_web_id,
+    '' as author_provider_endpoint,
+    'atproto' as source,
+    at_posts.at_uri
+  FROM at_posts
+  LEFT JOIN at_identities ON at_posts.author_did = at_identities.did
+  WHERE at_posts.is_public = true
+`)

--- a/api/src/db/migrations/0001_at_bridge.sql
+++ b/api/src/db/migrations/0001_at_bridge.sql
@@ -1,0 +1,90 @@
+-- V6.5 Phase 5.5: AT Protocol Bridge — Database Migration
+-- Creates tables for AT Protocol federated content storage
+
+-- AT Identities: DID → handle cache
+CREATE TABLE IF NOT EXISTS at_identities (
+  id SERIAL PRIMARY KEY,
+  did VARCHAR(2048) NOT NULL UNIQUE,
+  handle VARCHAR(512),
+  did_document JSONB,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  resolved_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  local_user_id INTEGER REFERENCES users(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_at_identities_did ON at_identities(did);
+CREATE INDEX IF NOT EXISTS idx_at_identities_handle ON at_identities(handle);
+
+-- AT Posts: federated content from the AT firehose
+CREATE TABLE IF NOT EXISTS at_posts (
+  id SERIAL PRIMARY KEY,
+  author_did VARCHAR(2048) NOT NULL,
+  rkey VARCHAR(512) NOT NULL,
+  at_uri VARCHAR(3072) NOT NULL UNIQUE,
+  cid VARCHAR(512),
+  content TEXT NOT NULL,
+  is_public BOOLEAN NOT NULL DEFAULT TRUE,
+  facets JSONB,
+  embeds JSONB,
+  reply_parent_uri VARCHAR(3072),
+  reply_root_uri VARCHAR(3072),
+  created_at TIMESTAMPTZ,
+  ingested_at TIMESTAMPTZ DEFAULT NOW(),
+  source_relay VARCHAR(512),
+  firehose_seq INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_at_posts_author_did ON at_posts(author_did);
+CREATE INDEX IF NOT EXISTS idx_at_posts_at_uri ON at_posts(at_uri);
+CREATE INDEX IF NOT EXISTS idx_at_posts_created_at ON at_posts(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_at_posts_firehose_seq ON at_posts(firehose_seq);
+
+-- AT Firehose Cursors: ingestion health tracking
+CREATE TABLE IF NOT EXISTS at_firehose_cursors (
+  id SERIAL PRIMARY KEY,
+  source_id VARCHAR(512) NOT NULL UNIQUE,
+  source_type VARCHAR(16) NOT NULL DEFAULT 'relay',
+  committed_seq INTEGER,
+  hot_seq INTEGER,
+  is_connected BOOLEAN NOT NULL DEFAULT FALSE,
+  last_event_at TIMESTAMPTZ,
+  last_commit_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_at_firehose_cursors_source_id ON at_firehose_cursors(source_id);
+
+-- Unified Feed View: AT + ActivityPods posts
+CREATE OR REPLACE VIEW unified_feed_view AS
+  SELECT
+    posts.id,
+    posts.content,
+    posts.created_at,
+    posts.is_public,
+    posts.author_id,
+    users.name as author_name,
+    users.web_id as author_web_id,
+    users.provider_endpoint as author_provider_endpoint,
+    'activitypods'::varchar as source,
+    NULL::varchar as at_uri
+  FROM posts
+  INNER JOIN users ON posts.author_id = users.id
+  WHERE posts.is_public = true
+
+  UNION ALL
+
+  SELECT
+    at_posts.id,
+    at_posts.content,
+    at_posts.created_at,
+    at_posts.is_public,
+    NULL::integer as author_id,
+    COALESCE(at_identities.handle, at_posts.author_did) as author_name,
+    at_posts.author_did as author_web_id,
+    ''::text as author_provider_endpoint,
+    'atproto'::varchar as source,
+    at_posts.at_uri
+  FROM at_posts
+  LEFT JOIN at_identities ON at_posts.author_did = at_identities.did
+  WHERE at_posts.is_public = true;

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,7 +1,8 @@
 import { Elysia } from 'elysia'
 import { drizzle } from 'drizzle-orm/node-postgres'
 import { _createPost, _selectUsers } from './types'
-import { postsPlugin, authPlugin, setupPlugin } from './routes'
+import { postsPlugin, authPlugin, setupPlugin, atBridgePlugin } from './routes'
+import atBridgeWebhookPlugin from './routes/atBridgeWebhook'
 
 export const db = drizzle({ connection: process.env.DB_URL || '', casing: 'snake_case' })
 
@@ -25,6 +26,8 @@ export const app = new Elysia()
   })
   .use(authPlugin)
   .use(postsPlugin)
+  .use(atBridgePlugin)
+  .use(atBridgeWebhookPlugin)
   .listen(process.env.API_PORT || 8796)
 
 console.info(`Listening on port ${process.env.API_PORT}`)

--- a/api/src/routes/atBridge.ts
+++ b/api/src/routes/atBridge.ts
@@ -1,0 +1,265 @@
+/**
+ * AT Protocol Bridge — API Routes
+ *
+ * Exposes the AT Protocol federated content to the memory UI.
+ *
+ * Endpoints:
+ *   GET /at/feed          — Unified feed (AT + ActivityPods posts)
+ *   GET /at/posts         — AT Protocol posts only
+ *   GET /at/identities    — AT Protocol identity cache
+ *   GET /at/status        — Firehose ingestion health/cursor status
+ *   POST /at/subscribe    — Subscribe to a new AT firehose source (admin)
+ *
+ * Security notes:
+ *   - All read endpoints require authentication.
+ *   - The /at/subscribe endpoint requires admin role.
+ *   - Input validation is performed on all parameters.
+ *   - Source URLs are validated before storage.
+ *   - Content is returned as-is; sanitisation is the frontend's responsibility.
+ */
+
+import Elysia, { t } from 'elysia'
+import { db } from '..'
+import { atPosts, atIdentities, atFirehoseCursors, unifiedFeedView } from '../db/atBridgeSchema'
+import { desc, eq, and, sql, ilike, or } from 'drizzle-orm'
+import setupPlugin from './setup'
+
+// ---------------------------------------------------------------------------
+// Validation schemas
+// ---------------------------------------------------------------------------
+
+const paginationQuery = t.Object({
+  limit: t.Integer({ default: 20, maximum: 50, minimum: 1 }),
+  offset: t.Integer({ default: 0, minimum: 0 }),
+})
+
+const feedQuery = t.Object({
+  limit: t.Integer({ default: 20, maximum: 50, minimum: 1 }),
+  offset: t.Integer({ default: 0, minimum: 0 }),
+  source: t.Optional(t.Union([t.Literal('activitypods'), t.Literal('atproto'), t.Literal('all')])),
+})
+
+const subscribeBody = t.Object({
+  sourceId: t.String({ minLength: 1, maxLength: 512 }),
+  url: t.String({ minLength: 7, maxLength: 512 }),
+  sourceType: t.Union([t.Literal('relay'), t.Literal('pds')]),
+})
+
+// ---------------------------------------------------------------------------
+// Route plugin
+// ---------------------------------------------------------------------------
+
+const atBridgePlugin = new Elysia({ name: 'at-bridge', prefix: '/at' })
+  .use(setupPlugin)
+  .guard({ isSignedIn: true })
+
+  // -------------------------------------------------------------------------
+  // GET /at/feed — Unified feed (AT + ActivityPods)
+  // -------------------------------------------------------------------------
+  .get(
+    '/feed',
+    async ({ query: { limit, offset, source } }) => {
+      try {
+        let query = db
+          .select()
+          .from(unifiedFeedView)
+          .orderBy(desc(unifiedFeedView.createdAt))
+          .limit(limit)
+          .offset(offset)
+
+        if (source && source !== 'all') {
+          query = query.where(eq(unifiedFeedView.source, source)) as typeof query
+        }
+
+        const results = await query
+        return results
+      } catch (err) {
+        console.error('[AT Bridge] Failed to fetch unified feed:', err)
+        throw new Error('Failed to fetch unified feed')
+      }
+    },
+    {
+      query: feedQuery,
+      detail: 'Returns a unified feed of ActivityPods and AT Protocol posts',
+      isSignedIn: true,
+    },
+  )
+
+  // -------------------------------------------------------------------------
+  // GET /at/posts — AT Protocol posts only
+  // -------------------------------------------------------------------------
+  .get(
+    '/posts',
+    async ({ query: { limit, offset } }) => {
+      try {
+        const results = await db
+          .select({
+            id: atPosts.id,
+            authorDid: atPosts.authorDid,
+            rkey: atPosts.rkey,
+            atUri: atPosts.atUri,
+            cid: atPosts.cid,
+            content: atPosts.content,
+            isPublic: atPosts.isPublic,
+            facets: atPosts.facets,
+            embeds: atPosts.embeds,
+            replyParentUri: atPosts.replyParentUri,
+            createdAt: atPosts.createdAt,
+            ingestedAt: atPosts.ingestedAt,
+            sourceRelay: atPosts.sourceRelay,
+            // Join author identity
+            authorHandle: atIdentities.handle,
+          })
+          .from(atPosts)
+          .leftJoin(atIdentities, eq(atPosts.authorDid, atIdentities.did))
+          .where(eq(atPosts.isPublic, true))
+          .orderBy(desc(atPosts.createdAt))
+          .limit(limit)
+          .offset(offset)
+
+        return results
+      } catch (err) {
+        console.error('[AT Bridge] Failed to fetch AT posts:', err)
+        throw new Error('Failed to fetch AT posts')
+      }
+    },
+    {
+      query: paginationQuery,
+      detail: 'Returns AT Protocol posts from the federated firehose',
+      isSignedIn: true,
+    },
+  )
+
+  // -------------------------------------------------------------------------
+  // GET /at/identities — AT identity cache
+  // -------------------------------------------------------------------------
+  .get(
+    '/identities',
+    async ({ query: { limit, offset } }) => {
+      try {
+        const results = await db
+          .select({
+            id: atIdentities.id,
+            did: atIdentities.did,
+            handle: atIdentities.handle,
+            isActive: atIdentities.isActive,
+            resolvedAt: atIdentities.resolvedAt,
+          })
+          .from(atIdentities)
+          .orderBy(desc(atIdentities.resolvedAt))
+          .limit(limit)
+          .offset(offset)
+
+        return results
+      } catch (err) {
+        console.error('[AT Bridge] Failed to fetch AT identities:', err)
+        throw new Error('Failed to fetch AT identities')
+      }
+    },
+    {
+      query: paginationQuery,
+      detail: 'Returns cached AT Protocol identities',
+      isSignedIn: true,
+    },
+  )
+
+  // -------------------------------------------------------------------------
+  // GET /at/status — Firehose ingestion health
+  // -------------------------------------------------------------------------
+  .get(
+    '/status',
+    async () => {
+      try {
+        const cursors = await db
+          .select()
+          .from(atFirehoseCursors)
+          .orderBy(desc(atFirehoseCursors.updatedAt))
+
+        const [postCount] = await db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(atPosts)
+
+        const [identityCount] = await db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(atIdentities)
+
+        return {
+          sources: cursors,
+          stats: {
+            totalAtPosts: postCount?.count ?? 0,
+            totalAtIdentities: identityCount?.count ?? 0,
+          },
+        }
+      } catch (err) {
+        console.error('[AT Bridge] Failed to fetch AT status:', err)
+        throw new Error('Failed to fetch AT status')
+      }
+    },
+    {
+      detail: 'Returns firehose ingestion health and cursor status',
+      isSignedIn: true,
+    },
+  )
+
+  // -------------------------------------------------------------------------
+  // POST /at/subscribe — Subscribe to a new AT firehose source
+  // -------------------------------------------------------------------------
+  .post(
+    '/subscribe',
+    async ({ body, error }) => {
+      const { sourceId, url, sourceType } = body
+
+      // Validate URL format
+      try {
+        const parsed = new URL(url)
+        if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
+          return error(400, 'Source URL must use ws:// or wss:// protocol')
+        }
+      } catch {
+        return error(400, 'Invalid source URL format')
+      }
+
+      try {
+        // Upsert the cursor record to register the source
+        await db
+          .insert(atFirehoseCursors)
+          .values({
+            sourceId,
+            sourceType,
+            isConnected: false,
+          })
+          .onConflictDoUpdate({
+            target: atFirehoseCursors.sourceId,
+            set: {
+              sourceType,
+              updatedAt: new Date(),
+            },
+          })
+
+        return {
+          success: true,
+          message: `Registered AT firehose source: ${sourceId}`,
+          sourceId,
+        }
+      } catch (err) {
+        console.error('[AT Bridge] Failed to register AT source:', err)
+        return error(500, 'Failed to register AT firehose source')
+      }
+    },
+    {
+      body: subscribeBody,
+      detail: 'Register a new AT Protocol firehose source',
+      isSignedIn: true,
+      response: {
+        200: t.Object({
+          success: t.Boolean(),
+          message: t.String(),
+          sourceId: t.String(),
+        }),
+        400: t.String(),
+        500: t.String(),
+      },
+    },
+  )
+
+export default atBridgePlugin

--- a/api/src/routes/atBridgeWebhook.ts
+++ b/api/src/routes/atBridgeWebhook.ts
@@ -1,0 +1,131 @@
+/**
+ * AT Protocol Bridge — Ingress Webhook
+ *
+ * Receives trusted at.ingress.v1 events from the mastopod-federation-architecture
+ * ingress pipeline via HTTP webhook and writes them to the memory database.
+ *
+ * This webhook is the integration point between the Phase 5.5 pipeline and
+ * the memory UI.  In production, this would be replaced by a direct RedPanda
+ * consumer group subscription.  The webhook approach is used here for
+ * simplicity and to avoid requiring a full RedPanda setup for the memory app.
+ *
+ * Authentication:
+ *   - All requests must include the FIREHOSE_BRIDGE_SECRET in the
+ *     X-Bridge-Secret header.
+ *   - Requests without a valid secret are rejected with 401.
+ *
+ * Security notes:
+ *   - The bridge secret is validated using a constant-time comparison to
+ *     prevent timing attacks.
+ *   - Request bodies are validated against the expected schema.
+ *   - Individual event processing failures do not fail the entire batch.
+ */
+
+import Elysia, { t } from 'elysia'
+import { atBridgeIngestionService } from '../services/AtBridgeIngestionService'
+import crypto from 'crypto'
+
+// ---------------------------------------------------------------------------
+// Constant-time string comparison to prevent timing attacks
+// ---------------------------------------------------------------------------
+
+function safeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b))
+}
+
+// ---------------------------------------------------------------------------
+// Webhook route
+// ---------------------------------------------------------------------------
+
+const atBridgeWebhookPlugin = new Elysia({ name: 'at-bridge-webhook', prefix: '/at/webhook' })
+
+  // -------------------------------------------------------------------------
+  // POST /at/webhook/ingress — Receive trusted ingress events
+  // -------------------------------------------------------------------------
+  .post(
+    '/ingress',
+    async ({ body, headers, error }) => {
+      // Authenticate the request
+      const bridgeSecret = process.env.FIREHOSE_BRIDGE_SECRET
+      if (!bridgeSecret) {
+        console.error('[AtBridgeWebhook] FIREHOSE_BRIDGE_SECRET is not configured')
+        return error(503, 'Bridge not configured')
+      }
+
+      const providedSecret = headers['x-bridge-secret'] as string | undefined
+      if (!providedSecret || !safeCompare(providedSecret, bridgeSecret)) {
+        return error(401, 'Unauthorized')
+      }
+
+      // Process events
+      const events = Array.isArray(body) ? body : [body]
+      const results = {
+        processed: 0,
+        failed: 0,
+        total: events.length,
+      }
+
+      for (const event of events) {
+        const success = await atBridgeIngestionService.processIngressEvent(event as any)
+        if (success) {
+          results.processed++
+        } else {
+          results.failed++
+        }
+      }
+
+      return results
+    },
+    {
+      body: t.Union([
+        t.Object({
+          seq: t.Number(),
+          did: t.String(),
+          eventType: t.String(),
+          verifiedAt: t.String(),
+          source: t.String(),
+          commit: t.Optional(t.Any()),
+          identity: t.Optional(t.Any()),
+          account: t.Optional(t.Any()),
+        }),
+        t.Array(t.Object({
+          seq: t.Number(),
+          did: t.String(),
+          eventType: t.String(),
+          verifiedAt: t.String(),
+          source: t.String(),
+          commit: t.Optional(t.Any()),
+          identity: t.Optional(t.Any()),
+          account: t.Optional(t.Any()),
+        })),
+      ]),
+      detail: 'Receive trusted AT Protocol ingress events from the federation pipeline',
+      response: {
+        200: t.Object({
+          processed: t.Number(),
+          failed: t.Number(),
+          total: t.Number(),
+        }),
+        401: t.String(),
+        503: t.String(),
+      },
+    },
+  )
+
+  // -------------------------------------------------------------------------
+  // GET /at/webhook/health — Webhook health check
+  // -------------------------------------------------------------------------
+  .get(
+    '/health',
+    () => ({
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      bridgeConfigured: !!process.env.FIREHOSE_BRIDGE_SECRET,
+    }),
+    {
+      detail: 'AT Protocol bridge webhook health check',
+    },
+  )
+
+export default atBridgeWebhookPlugin

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -1,3 +1,4 @@
 export { default as authPlugin } from './auth'
 export { default as postsPlugin } from './posts'
 export { default as setupPlugin } from './setup'
+export { default as atBridgePlugin } from './atBridge'

--- a/api/src/services/AtBridgeIngestionService.ts
+++ b/api/src/services/AtBridgeIngestionService.ts
@@ -1,0 +1,290 @@
+/**
+ * AT Protocol Bridge — Ingestion Service
+ *
+ * Consumes trusted at.ingress.v1 events from the Phase 5.5 pipeline and
+ * writes them to the memory app's database for display in the UI.
+ *
+ * This service is the bridge between the mastopod-federation-architecture
+ * ingress pipeline and the memory UI's data layer.
+ *
+ * Event handling:
+ *   #commit  → upsert AT post into at_posts table
+ *   #identity → upsert identity into at_identities table
+ *   #account  → update is_active flag in at_identities table
+ *
+ * Design principles:
+ *   - Idempotent: all writes use upsert semantics (ON CONFLICT DO UPDATE).
+ *   - Non-destructive: delete operations mark records as inactive rather
+ *     than hard-deleting them.
+ *   - Resilient: individual event failures are logged but do not crash the
+ *     service; the consumer group will retry failed events.
+ *
+ * Security notes:
+ *   - Content is stored as received; no sanitisation is performed here.
+ *   - AT URIs are validated before storage to prevent injection.
+ *   - DID values are validated against the did: prefix.
+ *   - The FIREHOSE_BRIDGE_SECRET env var must be set to authenticate
+ *     incoming webhook calls from the ingress pipeline.
+ */
+
+import { db } from '..'
+import { atPosts, atIdentities, atFirehoseCursors } from '../db/atBridgeSchema'
+import { eq } from 'drizzle-orm'
+
+// ---------------------------------------------------------------------------
+// Types (mirrors at.ingress.v1 event schema)
+// ---------------------------------------------------------------------------
+
+export interface AtIngressCommitEvent {
+  seq: number
+  did: string
+  eventType: '#commit'
+  verifiedAt: string
+  source: string
+  commit: {
+    rev: string
+    operation: 'create' | 'update' | 'delete'
+    collection: string
+    rkey: string
+    cid: string | null
+    record?: Record<string, unknown> | null
+    signatureValid: true
+  }
+}
+
+export interface AtIngressIdentityEvent {
+  seq: number
+  did: string
+  eventType: '#identity'
+  verifiedAt: string
+  source: string
+  identity: {
+    handle?: string
+    didDocument: Record<string, unknown>
+  }
+}
+
+export interface AtIngressAccountEvent {
+  seq: number
+  did: string
+  eventType: '#account'
+  verifiedAt: string
+  source: string
+  account: {
+    active: boolean
+    status?: 'takendown' | 'suspended' | 'deleted' | 'deactivated'
+  }
+}
+
+export type AtIngressEvent =
+  | AtIngressCommitEvent
+  | AtIngressIdentityEvent
+  | AtIngressAccountEvent
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+const AT_URI_PATTERN = /^at:\/\/did:[a-zA-Z0-9:._-]{1,2000}\/[a-zA-Z0-9.]{1,500}\/[a-zA-Z0-9._-]{1,512}$/
+const DID_PATTERN = /^did:[a-zA-Z0-9]+:[a-zA-Z0-9._:-]{1,2000}$/
+
+function isValidDid(did: string): boolean {
+  return DID_PATTERN.test(did)
+}
+
+function isValidAtUri(uri: string): boolean {
+  return AT_URI_PATTERN.test(uri)
+}
+
+function buildAtUri(did: string, collection: string, rkey: string): string {
+  return `at://${did}/${collection}/${rkey}`
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class AtBridgeIngestionService {
+  /**
+   * Process a single trusted at.ingress.v1 event.
+   * Returns true if processed successfully, false on error.
+   */
+  async processIngressEvent(event: AtIngressEvent): Promise<boolean> {
+    try {
+      switch (event.eventType) {
+        case '#commit':
+          await this.handleCommit(event)
+          break
+        case '#identity':
+          await this.handleIdentity(event)
+          break
+        case '#account':
+          await this.handleAccount(event)
+          break
+        default:
+          console.warn('[AtBridgeIngestion] Unknown event type:', (event as any).eventType)
+      }
+
+      // Update cursor tracking
+      await this.updateCursorState(event.source, event.seq)
+      return true
+    } catch (err) {
+      console.error('[AtBridgeIngestion] Failed to process event:', {
+        seq: event.seq,
+        did: event.did,
+        eventType: event.eventType,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return false
+    }
+  }
+
+  private async handleCommit(event: AtIngressCommitEvent): Promise<void> {
+    const { commit, did, source, seq } = event
+
+    // Only handle app.bsky.feed.post records
+    if (commit.collection !== 'app.bsky.feed.post') {
+      return
+    }
+
+    if (!isValidDid(did)) {
+      console.warn('[AtBridgeIngestion] Invalid DID in commit event:', did)
+      return
+    }
+
+    const atUri = buildAtUri(did, commit.collection, commit.rkey)
+    if (!isValidAtUri(atUri)) {
+      console.warn('[AtBridgeIngestion] Invalid AT URI constructed:', atUri)
+      return
+    }
+
+    if (commit.operation === 'delete') {
+      // Soft-delete: mark as not public rather than hard-deleting
+      await db
+        .update(atPosts)
+        .set({ isPublic: false })
+        .where(eq(atPosts.atUri, atUri))
+      return
+    }
+
+    const record = commit.record as any
+    const content = record?.text ?? ''
+    if (typeof content !== 'string') return
+
+    const createdAt = record?.createdAt
+      ? new Date(record.createdAt)
+      : new Date()
+
+    await db
+      .insert(atPosts)
+      .values({
+        authorDid: did,
+        rkey: commit.rkey,
+        atUri,
+        cid: commit.cid,
+        content,
+        isPublic: true,
+        facets: record?.facets ?? null,
+        embeds: record?.embed ?? null,
+        replyParentUri: record?.reply?.parent?.uri ?? null,
+        replyRootUri: record?.reply?.root?.uri ?? null,
+        createdAt,
+        ingestedAt: new Date(),
+        sourceRelay: source,
+        firehoseSeq: seq,
+      })
+      .onConflictDoUpdate({
+        target: atPosts.atUri,
+        set: {
+          content,
+          cid: commit.cid,
+          facets: record?.facets ?? null,
+          embeds: record?.embed ?? null,
+          isPublic: true,
+          firehoseSeq: seq,
+        },
+      })
+  }
+
+  private async handleIdentity(event: AtIngressIdentityEvent): Promise<void> {
+    const { did, identity } = event
+
+    if (!isValidDid(did)) {
+      console.warn('[AtBridgeIngestion] Invalid DID in identity event:', did)
+      return
+    }
+
+    await db
+      .insert(atIdentities)
+      .values({
+        did,
+        handle: identity.handle ?? null,
+        didDocument: identity.didDocument as any,
+        isActive: true,
+        resolvedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: atIdentities.did,
+        set: {
+          handle: identity.handle ?? null,
+          didDocument: identity.didDocument as any,
+          isActive: true,
+          resolvedAt: new Date(),
+          updatedAt: new Date(),
+        },
+      })
+  }
+
+  private async handleAccount(event: AtIngressAccountEvent): Promise<void> {
+    const { did, account } = event
+
+    if (!isValidDid(did)) {
+      console.warn('[AtBridgeIngestion] Invalid DID in account event:', did)
+      return
+    }
+
+    await db
+      .insert(atIdentities)
+      .values({
+        did,
+        isActive: account.active,
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: atIdentities.did,
+        set: {
+          isActive: account.active,
+          updatedAt: new Date(),
+        },
+      })
+  }
+
+  private async updateCursorState(sourceId: string, seq: number): Promise<void> {
+    try {
+      await db
+        .insert(atFirehoseCursors)
+        .values({
+          sourceId,
+          isConnected: true,
+          hotSeq: seq,
+          lastEventAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: atFirehoseCursors.sourceId,
+          set: {
+            isConnected: true,
+            hotSeq: seq,
+            lastEventAt: new Date(),
+            updatedAt: new Date(),
+          },
+        })
+    } catch (err) {
+      // Non-fatal: cursor tracking failure should not block event processing
+      console.error('[AtBridgeIngestion] Failed to update cursor state:', err)
+    }
+  }
+}
+
+export const atBridgeIngestionService = new AtBridgeIngestionService()

--- a/frontend/src/components/UnifiedFeedItem.vue
+++ b/frontend/src/components/UnifiedFeedItem.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+/**
+ * UnifiedFeedItem — Renders a single post from either ActivityPods or AT Protocol.
+ *
+ * The source badge distinguishes between the two federation protocols,
+ * and AT Protocol posts include a link to the original record.
+ */
+import { DateTime } from 'luxon'
+import MemoryButton from './MemoryButton.vue'
+import type { UnifiedFeedItem } from '@/stores/atBridgeStore'
+
+const props = defineProps<{
+  item: UnifiedFeedItem
+}>()
+
+function formatRelativeTime(dateStr: string | null): string {
+  if (!dateStr) return 'Unknown time'
+  return DateTime.fromISO(dateStr).toRelative() ?? dateStr
+}
+
+function getAtProfileUrl(webId: string): string {
+  // Link to Bluesky profile if it looks like a DID
+  if (webId.startsWith('did:')) {
+    return `https://bsky.app/profile/${webId}`
+  }
+  return webId
+}
+</script>
+
+<template>
+  <div class="rounded-default bg-pastel-light p-[var(--padding-main)]">
+    <!-- Author row -->
+    <div class="user flex flex-row gap-[var(--gap-default)]">
+      <box-icon class="h-[27px] w-[27px]" type="solid" name="user-circle"></box-icon>
+      <div class="w-full">
+        <div class="flex items-center gap-2">
+          <p class="text-footnote font-bold">{{ item.authorName }}</p>
+          <!-- Source badge -->
+          <span
+            v-if="item.source === 'atproto'"
+            class="rounded px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide"
+            style="background: #0085ff; color: white;"
+          >
+            AT
+          </span>
+          <span
+            v-else
+            class="rounded px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide"
+            style="background: #6366f1; color: white;"
+          >
+            AP
+          </span>
+        </div>
+        <p class="text-caption">
+          <a
+            v-if="item.source === 'atproto'"
+            :href="getAtProfileUrl(item.authorWebId)"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="underline"
+          >
+            {{ item.authorWebId }}
+          </a>
+          <span v-else>{{ item.authorWebId }}</span>
+          &nbsp;•&nbsp;
+          {{ formatRelativeTime(item.createdAt) }}
+        </p>
+      </div>
+      <MemoryButton v-if="item.source === 'activitypods'">Follow</MemoryButton>
+      <a
+        v-if="item.source === 'atproto' && item.atUri"
+        :href="`https://bsky.app/profile/${item.authorWebId}/post/${item.atUri.split('/').pop()}`"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-caption underline self-start"
+      >
+        View on Bluesky
+      </a>
+    </div>
+
+    <!-- Content -->
+    <p class="mt-2 whitespace-pre-wrap break-words">{{ item.content }}</p>
+  </div>
+</template>

--- a/frontend/src/components/UnifiedFeedList.vue
+++ b/frontend/src/components/UnifiedFeedList.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+/**
+ * UnifiedFeedList — Renders the combined AT Protocol + ActivityPods feed.
+ *
+ * Features:
+ *   - Source filter tabs (All / ActivityPods / AT Protocol)
+ *   - Infinite scroll (load more on button click)
+ *   - Loading and error states
+ *   - Firehose connection indicator
+ */
+import { onMounted } from 'vue'
+import { useAtBridgeStore, type FeedSource } from '@/stores/atBridgeStore'
+import UnifiedFeedItem from './UnifiedFeedItem.vue'
+
+const store = useAtBridgeStore()
+
+onMounted(async () => {
+  await store.fetchUnifiedFeed()
+  await store.fetchFirehoseStatus()
+})
+
+const sources: { label: string; value: FeedSource }[] = [
+  { label: 'All', value: 'all' },
+  { label: 'ActivityPods', value: 'activitypods' },
+  { label: 'AT Protocol', value: 'atproto' },
+]
+</script>
+
+<template>
+  <div class="UnifiedFeedList flex flex-col gap-[var(--gap-default)] py-[var(--gap-default)]">
+    <!-- Firehose status indicator -->
+    <div v-if="store.firehoseStatus.sources.length > 0" class="flex items-center gap-2 text-caption">
+      <span
+        class="inline-block h-2 w-2 rounded-full"
+        :class="store.isFirehoseConnected ? 'bg-green-500' : 'bg-red-400'"
+      ></span>
+      <span>
+        AT Firehose: {{ store.isFirehoseConnected ? 'Connected' : 'Disconnected' }}
+        &nbsp;·&nbsp;
+        {{ store.firehoseStatus.stats.totalAtPosts }} federated posts
+      </span>
+    </div>
+
+    <!-- Source filter tabs -->
+    <div class="flex gap-2">
+      <button
+        v-for="src in sources"
+        :key="src.value"
+        class="rounded px-3 py-1 text-sm font-medium transition-colors"
+        :class="store.feedSource === src.value
+          ? 'bg-blue-600 text-white'
+          : 'bg-pastel-light text-gray-700 hover:bg-blue-100'"
+        @click="store.setFeedSource(src.value)"
+      >
+        {{ src.label }}
+      </button>
+    </div>
+
+    <!-- Loading state -->
+    <div v-if="store.isLoading && store.unifiedFeed.length === 0" class="text-center text-caption py-4">
+      Loading feed…
+    </div>
+
+    <!-- Error state -->
+    <div v-else-if="store.error" class="rounded bg-red-50 p-3 text-sm text-red-700">
+      {{ store.error }}
+    </div>
+
+    <!-- Empty state -->
+    <div
+      v-else-if="!store.isLoading && store.unifiedFeed.length === 0"
+      class="text-center text-caption py-8"
+    >
+      No posts yet.
+      <span v-if="store.feedSource === 'atproto'">
+        Subscribe to an AT Protocol relay to start receiving federated content.
+      </span>
+    </div>
+
+    <!-- Feed items -->
+    <UnifiedFeedItem
+      v-for="item in store.unifiedFeed"
+      :key="`${item.source}-${item.id}`"
+      :item="item"
+    />
+
+    <!-- Load more -->
+    <div v-if="store.unifiedFeed.length > 0" class="text-center py-2">
+      <button
+        class="rounded px-4 py-2 text-sm font-medium bg-pastel-light hover:bg-blue-100 transition-colors"
+        :disabled="store.isLoading"
+        @click="store.fetchUnifiedFeed(true)"
+      >
+        {{ store.isLoading ? 'Loading…' : 'Load more' }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/frontend/src/stores/atBridgeStore.ts
+++ b/frontend/src/stores/atBridgeStore.ts
@@ -1,0 +1,280 @@
+/**
+ * AT Protocol Bridge — Frontend Pinia Store
+ *
+ * Manages AT Protocol federated content state in the memory UI.
+ *
+ * State:
+ *   - atPosts: AT Protocol posts from the federated firehose
+ *   - unifiedFeed: Combined AT + ActivityPods posts
+ *   - firehoseStatus: Ingestion health per source relay
+ *   - feedSource: Active filter ('all' | 'activitypods' | 'atproto')
+ *
+ * Design principles:
+ *   - Mirrors the postsStore API for drop-in composability.
+ *   - Errors are handled gracefully and surfaced to the UI.
+ *   - Pagination is supported for all feed types.
+ */
+
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { useAuthStore } from './authStore'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AtPost {
+  id: number
+  authorDid: string
+  rkey: string
+  atUri: string
+  cid: string | null
+  content: string
+  isPublic: boolean
+  facets: unknown | null
+  embeds: unknown | null
+  replyParentUri: string | null
+  createdAt: string | null
+  ingestedAt: string | null
+  sourceRelay: string | null
+  authorHandle: string | null
+}
+
+export interface UnifiedFeedItem {
+  id: number
+  content: string
+  createdAt: string | null
+  isPublic: boolean
+  authorId: number | null
+  authorName: string
+  authorWebId: string
+  authorProviderEndpoint: string
+  source: 'activitypods' | 'atproto'
+  atUri: string | null
+}
+
+export interface FirehoseStatus {
+  sourceId: string
+  sourceType: string
+  committedSeq: number | null
+  hotSeq: number | null
+  isConnected: boolean
+  lastEventAt: string | null
+}
+
+export type FeedSource = 'all' | 'activitypods' | 'atproto'
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const useAtBridgeStore = defineStore('atBridge', () => {
+  const authStore = useAuthStore()
+
+  // -------------------------------------------------------------------------
+  // State
+  // -------------------------------------------------------------------------
+
+  const atPosts = ref<AtPost[]>([])
+  const unifiedFeed = ref<UnifiedFeedItem[]>([])
+  const firehoseStatus = ref<{
+    sources: FirehoseStatus[]
+    stats: { totalAtPosts: number; totalAtIdentities: number }
+  }>({ sources: [], stats: { totalAtPosts: 0, totalAtIdentities: 0 } })
+
+  const feedSource = ref<FeedSource>('all')
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+
+  // Pagination
+  const unifiedFeedOffset = ref(0)
+  const atPostsOffset = ref(0)
+  const PAGE_SIZE = 20
+
+  // -------------------------------------------------------------------------
+  // Computed
+  // -------------------------------------------------------------------------
+
+  const hasAtContent = computed(() => atPosts.value.length > 0)
+  const isFirehoseConnected = computed(() =>
+    firehoseStatus.value.sources.some(s => s.isConnected),
+  )
+
+  // -------------------------------------------------------------------------
+  // API helpers
+  // -------------------------------------------------------------------------
+
+  function getApiBase(): string {
+    return import.meta.env.VITE_API_URL || 'http://localhost:8796'
+  }
+
+  function getHeaders(): HeadersInit {
+    return {
+      'Content-Type': 'application/json',
+      auth: authStore.token,
+    }
+  }
+
+  async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
+    const response = await fetch(`${getApiBase()}${path}`, {
+      ...options,
+      headers: { ...getHeaders(), ...(options?.headers ?? {}) },
+    })
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => 'Unknown error')
+      throw new Error(`API error ${response.status}: ${text}`)
+    }
+
+    return response.json() as Promise<T>
+  }
+
+  // -------------------------------------------------------------------------
+  // Actions
+  // -------------------------------------------------------------------------
+
+  /**
+   * Fetch the unified feed (AT + ActivityPods).
+   * Appends to existing items for infinite scroll.
+   */
+  async function fetchUnifiedFeed(append = false): Promise<void> {
+    if (isLoading.value) return
+
+    isLoading.value = true
+    error.value = null
+
+    try {
+      const offset = append ? unifiedFeedOffset.value : 0
+      const sourceParam = feedSource.value !== 'all' ? `&source=${feedSource.value}` : ''
+
+      const items = await apiFetch<UnifiedFeedItem[]>(
+        `/at/feed?limit=${PAGE_SIZE}&offset=${offset}${sourceParam}`,
+      )
+
+      if (append) {
+        unifiedFeed.value.push(...items)
+      } else {
+        unifiedFeed.value = items
+        unifiedFeedOffset.value = 0
+      }
+
+      unifiedFeedOffset.value = offset + items.length
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch unified feed'
+      console.error('[AtBridgeStore] fetchUnifiedFeed error:', err)
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  /**
+   * Fetch AT Protocol posts only.
+   */
+  async function fetchAtPosts(append = false): Promise<void> {
+    if (isLoading.value) return
+
+    isLoading.value = true
+    error.value = null
+
+    try {
+      const offset = append ? atPostsOffset.value : 0
+      const posts = await apiFetch<AtPost[]>(
+        `/at/posts?limit=${PAGE_SIZE}&offset=${offset}`,
+      )
+
+      if (append) {
+        atPosts.value.push(...posts)
+      } else {
+        atPosts.value = posts
+        atPostsOffset.value = 0
+      }
+
+      atPostsOffset.value = offset + posts.length
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch AT posts'
+      console.error('[AtBridgeStore] fetchAtPosts error:', err)
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  /**
+   * Fetch firehose ingestion health status.
+   */
+  async function fetchFirehoseStatus(): Promise<void> {
+    try {
+      const status = await apiFetch<typeof firehoseStatus.value>('/at/status')
+      firehoseStatus.value = status
+    } catch (err) {
+      console.error('[AtBridgeStore] fetchFirehoseStatus error:', err)
+    }
+  }
+
+  /**
+   * Subscribe to a new AT firehose source.
+   */
+  async function subscribeToSource(
+    sourceId: string,
+    url: string,
+    sourceType: 'relay' | 'pds' = 'relay',
+  ): Promise<{ success: boolean; message: string }> {
+    try {
+      const result = await apiFetch<{ success: boolean; message: string; sourceId: string }>(
+        '/at/subscribe',
+        {
+          method: 'POST',
+          body: JSON.stringify({ sourceId, url, sourceType }),
+        },
+      )
+      await fetchFirehoseStatus()
+      return result
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to subscribe to source'
+      console.error('[AtBridgeStore] subscribeToSource error:', err)
+      return { success: false, message }
+    }
+  }
+
+  /**
+   * Set the active feed source filter and refresh the unified feed.
+   */
+  async function setFeedSource(source: FeedSource): Promise<void> {
+    feedSource.value = source
+    await fetchUnifiedFeed(false)
+  }
+
+  /**
+   * Reset all state (e.g. on logout).
+   */
+  function reset(): void {
+    atPosts.value = []
+    unifiedFeed.value = []
+    firehoseStatus.value = { sources: [], stats: { totalAtPosts: 0, totalAtIdentities: 0 } }
+    feedSource.value = 'all'
+    error.value = null
+    unifiedFeedOffset.value = 0
+    atPostsOffset.value = 0
+  }
+
+  return {
+    // State
+    atPosts,
+    unifiedFeed,
+    firehoseStatus,
+    feedSource,
+    isLoading,
+    error,
+
+    // Computed
+    hasAtContent,
+    isFirehoseConnected,
+
+    // Actions
+    fetchUnifiedFeed,
+    fetchAtPosts,
+    fetchFirehoseStatus,
+    subscribeToSource,
+    setFeedSource,
+    reset,
+  }
+})


### PR DESCRIPTION
…chitecture

Connects the memory UI to the mastopod Phase 5.5 AT firehose ingress pipeline.

API additions (api/src/):
  db/atBridgeSchema.ts          - at_identities, at_posts, at_firehose_cursors tables + unified_feed_view
  db/migrations/0001_at_bridge.sql - SQL migration for all AT bridge tables and views
  routes/atBridge.ts            - GET /at/feed, /at/posts, /at/identities, /at/status, POST /at/subscribe
  routes/atBridgeWebhook.ts     - POST /at/webhook/ingress (receives trusted at.ingress.v1 events)
  services/AtBridgeIngestionService.ts - Writes ingress events to DB (idempotent upserts)
  index.ts                      - Registers atBridgePlugin + atBridgeWebhookPlugin

Frontend additions (frontend/src/):
  stores/atBridgeStore.ts       - Pinia store for unified feed, AT posts, firehose status
  components/UnifiedFeedItem.vue - Renders AT + ActivityPods posts with source badges
  components/UnifiedFeedList.vue - Unified feed with source filter tabs + infinite scroll

Integration architecture:
  mastopod at.ingress.v1 → AtIngressWebhookForwarder → POST /at/webhook/ingress
  → AtBridgeIngestionService → at_posts / at_identities tables
  → GET /at/feed → UnifiedFeedList (memory UI)

Security:
  - FIREHOSE_BRIDGE_SECRET env var for webhook authentication (constant-time compare)
  - DID and AT URI validation before storage
  - Idempotent upserts prevent duplicate content