### PR TITLE
Phase 5.5: Full local stack setup + HomeView federated feed tab

### DIFF
--- a/api/drizzle.config.ts
+++ b/api/drizzle.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'drizzle-kit'
 
 export default defineConfig({
   out: './drizzle',
-  schema: './src/db/schema.ts',
+  schema: ['./src/db/schema.ts', './src/db/atBridgeSchema.ts'],
   dialect: 'postgresql',
   dbCredentials: {
     url: process.env.DB_URL || 'postgres://postgres:postgres@pg:5432/postgres'

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -7,6 +7,8 @@ import atBridgeWebhookPlugin from './routes/atBridgeWebhook'
 export const db = drizzle({ connection: process.env.DB_URL || '', casing: 'snake_case' })
 
 export const app = new Elysia()
+  // Top-level health check — used by Docker healthcheck and the Mastopod harness
+  .get('/health', () => ({ status: 'ok', timestamp: new Date().toISOString() }))
   .use(setupPlugin)
   .macro({
     isSignedIn: enabled => {

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,101 @@
+# ============================================================================
+# Memory App + AT Protocol Bridge — Full Local Stack
+#
+# Runs everything you need to see the Memory app in your browser with live
+# AT Protocol federated content flowing in from the Mastopod sidecar.
+#
+# Services:
+#   pg        — PostgreSQL 17 database
+#   api       — Memory API (Elysia/Bun) on http://localhost:8794
+#   frontend  — Memory UI (Vite/Vue) on http://localhost:5173
+#   mastopod  — AT Protocol ingress pipeline (Phase 5.5 local harness)
+#
+# Usage:
+#   docker compose -f docker-compose.local.yml up --build
+#
+# Then open: http://localhost:5173
+# ============================================================================
+
+services:
+
+  # --------------------------------------------------------------------------
+  # PostgreSQL — the database for the Memory API
+  # --------------------------------------------------------------------------
+  pg:
+    image: postgres:17
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: localpassword
+      POSTGRES_DB: memory
+    ports:
+      - '5432:5432'
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # --------------------------------------------------------------------------
+  # Memory API — Elysia/Bun backend
+  # --------------------------------------------------------------------------
+  api:
+    build:
+      context: .
+      dockerfile: docker/api.dockerfile
+    restart: unless-stopped
+    depends_on:
+      pg:
+        condition: service_healthy
+    ports:
+      - '8794:8794'
+    environment:
+      DB_URL: postgres://postgres:localpassword@pg:5432/memory
+      JWT_SECRET: local-dev-jwt-secret-change-in-prod
+      API_PORT: 8794
+      FRONTEND_URL: http://localhost:5173
+      FIREHOSE_BRIDGE_SECRET: local-bridge-secret-123
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -sf http://localhost:8794/health || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
+  # --------------------------------------------------------------------------
+  # Memory Frontend — Vite/Vue dev server
+  # --------------------------------------------------------------------------
+  frontend:
+    build:
+      context: .
+      dockerfile: docker/frontend.dockerfile
+      args:
+        VITE_API_URL: http://localhost:8794
+    restart: unless-stopped
+    depends_on:
+      - api
+    ports:
+      - '5173:5173'
+
+  # --------------------------------------------------------------------------
+  # Mastopod AT Protocol Ingress Pipeline (Phase 5.5 local harness)
+  # Runs the mock firehose + full ingress pipeline and forwards verified events
+  # to the Memory API webhook endpoint.
+  # --------------------------------------------------------------------------
+  mastopod:
+    build:
+      context: ../mastopod-federation-architecture/fedify-sidecar
+      dockerfile: Dockerfile.local
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_healthy
+    environment:
+      MEMORY_WEBHOOK_URL: http://api:8794/at/webhook/ingress
+      FIREHOSE_BRIDGE_SECRET: local-bridge-secret-123
+      # Set to 'true' to connect to the real Bluesky relay instead of the mock
+      USE_REAL_FIREHOSE: 'false'
+
+volumes:
+  pg_data:

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,11 +1,46 @@
 <script setup lang="ts">
 import CreatePostForm from '@/components/CreatePostForm.vue'
 import PostList from '@/components/PostList.vue'
+import UnifiedFeedList from '@/components/UnifiedFeedList.vue'
+import { ref } from 'vue'
+
+type Tab = 'my-posts' | 'federated'
+const activeTab = ref<Tab>('federated')
 </script>
 
 <template>
-  <div>
-    <CreatePostForm />
-    <PostList />
+  <div class="flex flex-col gap-4">
+    <!-- Tab switcher -->
+    <div class="flex gap-2 border-b border-gray-200 pb-2">
+      <button
+        class="rounded-t px-4 py-2 text-sm font-semibold transition-colors"
+        :class="activeTab === 'federated'
+          ? 'border-b-2 border-blue-600 text-blue-600'
+          : 'text-gray-500 hover:text-gray-700'"
+        @click="activeTab = 'federated'"
+      >
+        🌐 Federated Feed
+      </button>
+      <button
+        class="rounded-t px-4 py-2 text-sm font-semibold transition-colors"
+        :class="activeTab === 'my-posts'
+          ? 'border-b-2 border-blue-600 text-blue-600'
+          : 'text-gray-500 hover:text-gray-700'"
+        @click="activeTab = 'my-posts'"
+      >
+        ✍️ My Posts
+      </button>
+    </div>
+
+    <!-- Federated Feed (AT Protocol + ActivityPods) -->
+    <div v-if="activeTab === 'federated'">
+      <UnifiedFeedList />
+    </div>
+
+    <!-- My Posts -->
+    <div v-if="activeTab === 'my-posts'">
+      <CreatePostForm />
+      <PostList />
+    </div>
   </div>
 </template>


### PR DESCRIPTION
docker-compose.local.yml:
  - Complete local stack: PostgreSQL + Memory API + Vite frontend + Mastopod sidecar
  - All services wired together via Docker internal network
  - Shared FIREHOSE_BRIDGE_SECRET for HMAC-authenticated webhook
  - Health checks on API before Mastopod starts forwarding events

api/src/index.ts:
  - Added GET /health endpoint for Docker healthcheck and Mastopod wait-for-api

api/drizzle.config.ts:
  - Include atBridgeSchema.ts in schema array so drizzle:push creates AT tables

frontend/src/views/HomeView.vue:
  - Added tab navigation: 'Federated Feed' (default) and 'My Posts'
  - Federated Feed tab renders UnifiedFeedList (AT Protocol + ActivityPods)
  - My Posts tab retains existing CreatePostForm + PostList